### PR TITLE
ユーザー削除機能実装

### DIFF
--- a/src/components/ChatBoard.vue
+++ b/src/components/ChatBoard.vue
@@ -107,6 +107,7 @@
           </v-img>
         </v-card>
         <Signout />
+        <DeleteUser />
         <div class="text-center">
           <v-btn class="ma-2" outlined color="indigo" @click="changeImage"
             >プロフィール画像変更</v-btn
@@ -123,11 +124,13 @@ import { db } from "../plugins/firebase";
 import firebase from "firebase";
 import ChatForm from "@/components/Form.vue";
 import Signout from "@/components/Signout.vue";
+import DeleteUser from "@/components/DeleteUser.vue";
 export default {
   name: "ChatBoard",
   components: {
     Signout,
-    ChatForm
+    ChatForm,
+    DeleteUser
   },
   data: () => ({
     comments: [],

--- a/src/components/DeleteUser.vue
+++ b/src/components/DeleteUser.vue
@@ -1,0 +1,58 @@
+<template>
+  <v-row justify="center">
+    <v-dialog v-model="dialog" persistent max-width="290">
+      <template v-slot:activator="{ on }">
+        <v-btn color="primary" dark v-on="on">アカウント削除</v-btn>
+      </template>
+      <v-card>
+        <v-card-title class="headline">アカウントを削除しますか?</v-card-title>
+        <v-card-text
+          >このアカウントに関するデータは完全に消去され、元に戻せなくなります。</v-card-text
+        >
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn color="green darken-1" text @click="dialog = false"
+            >戻る</v-btn
+          >
+          <v-btn color="green darken-1" text @click="deleteUser"
+            >削除する</v-btn
+          >
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </v-row>
+</template>
+
+<script>
+import { db } from "../plugins/firebase";
+import firebase from "firebase";
+
+export default {
+  name: "DeleteUser",
+  data: () => {
+    return { dialog: false };
+  },
+
+  methods: {
+    deleteUser() {
+      let user = firebase.auth().currentUser;
+      user
+        .delete()
+        .then(() => {
+          db.collection("usersCollection")
+            .doc(user.uid)
+            .delete()
+            .then(function() {
+              alert("Document successfully deleted!");
+            })
+            .catch(function(error) {
+              alert("Error removing document: ", error);
+            });
+        })
+        .catch(error => {
+          alert(error);
+        });
+    }
+  }
+};
+</script>


### PR DESCRIPTION
アカウント削除ボタンを押すとアカウントが削除できるようにした。
auth().currentUserの削除とfirestoreのusersCollectionの削除をする。

https://github.com/soya111/2020-2-25-vue-firestore-chat/issues/8